### PR TITLE
Add missing header files evt2.h evt3.h dat.h to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include expelliarmus/src/wizard.h expelliarmus/src/wizard.c expelliarmus/src/events.h
+include expelliarmus/src/wizard.h expelliarmus/src/wizard.c expelliarmus/src/events.h expelliarmus/src/dat.h expelliarmus/src/evt2.h expelliarmus/src/evt3.h


### PR DESCRIPTION
Hiya, I'm trying to package [expelliarmus](https://github.com/open-neuromorphic/expelliarmus) for conda-forge (https://github.com/conda-forge/staged-recipes/pull/21648 - please let me know if you are interested in becoming a maintainer). When doing so, I noticed that some header files are missing in the source distribution, leading to a build error. This PR (+ a new release) should fix it.