### PR TITLE
Allow time_window / chunk_size change without reset

### DIFF
--- a/expelliarmus/src/dat.c
+++ b/expelliarmus/src/dat.c
@@ -241,8 +241,6 @@ DLLEXPORT size_t cut_dat(const char* fpath_in,
 	size_t values_read=0, j=0, i=0; 
 	// Values to keep track of overflows and of first timestamp encountered.
 	uint64_t time_ovfs=0, timestamp=0, first_timestamp=0; 
-	// Converting duration from milliseconds to microseconds.
-	new_duration *= 1000; 
 	while ( (timestamp-first_timestamp) < (uint64_t)new_duration && 
             (values_read = fread(buff, sizeof(*buff), buff_size, fp_in)) > 0 ){
 		for (j=0; 
@@ -263,4 +261,3 @@ DLLEXPORT size_t cut_dat(const char* fpath_in,
 	fclose(fp_out); 
 	return i; 
 }
-

--- a/expelliarmus/src/evt2.c
+++ b/expelliarmus/src/evt2.c
@@ -311,8 +311,6 @@ DLLEXPORT size_t cut_evt2(  const char* fpath_in,
 	uint64_t first_timestamp=0, timestamp=0, time_high=0, time_low=0;
 	// Masks to extract bits.
 	const uint32_t mask_28b = 0xFFFFFFFU, mask_6b=0x3FU; 
-	// Converting duration from milliseconds to microseconds.
-	new_duration *= 1000;
 	while ( (timestamp-first_timestamp) < (uint64_t)new_duration && 
             (values_read = fread(buff, sizeof(*buff), buff_size, fp_in)) > 0 ){
 		for (j=0; 
@@ -353,4 +351,3 @@ DLLEXPORT size_t cut_evt2(  const char* fpath_in,
 	free(buff); 
 	return i; 
 }
-

--- a/expelliarmus/src/evt3.c
+++ b/expelliarmus/src/evt3.c
@@ -491,8 +491,6 @@ DLLEXPORT size_t cut_evt3(  const char* fpath_in,
 	// Temporary values.
 	uint64_t first_timestamp=0, timestamp=0, time_high=0, time_high_ovfs=0, 
              time_low=0, time_low_ovfs=0; 
-	// Converting duration to microseconds.
-	new_duration *= 1000; 
 
 	while ( !get_out && 
             (values_read = fread(buff, sizeof(*buff), buff_size, fp_in)) > 0){

--- a/expelliarmus/wizard/wizard.py
+++ b/expelliarmus/wizard/wizard.py
@@ -38,7 +38,7 @@ class Wizard:
     :param fpath: the file to be read, either in chunks or fully.
     :param buff_size: the size of the buffer used to read the binary file.
     :param chunk_size: the chunk lenght when reading files in chunks.
-    :param time_window: the time window lenght in millisecond when reading files in chunks of milliseconds.
+    :param time_window: the time window length in microseconds when reading files in time chunks.
     """
 
     def __init__(
@@ -99,7 +99,7 @@ class Wizard:
     @property
     def time_window(self) -> int:
         """
-        The time window lenght, expressed in milliseconds.
+        The time window lenght, expressed in microseconds.
 
         :returns: the time window length.
         """
@@ -204,7 +204,7 @@ class Wizard:
 
         :param fpath_in: path to input file.
         :param fpath_out: path to output file.
-        :param new_duration: the desired duration, expressed in milliseconds.
+        :param new_duration: the desired duration, expressed in microseconds.
 
         :returns: the number of events encoded in the output file.
         """

--- a/expelliarmus/wizard/wizard.py
+++ b/expelliarmus/wizard/wizard.py
@@ -138,7 +138,7 @@ class Wizard:
         self.reset()
         return
 
-    def set_chunk_size(self, chunk_size: int) -> None:
+    def set_chunk_size(self, chunk_size: int, do_reset: bool = True) -> None:
         """
         Function to sets the size of the chunks to be read.
         WARNING: due to the vectorized events in event files, the chunks can be longer that 'chunk_size' (at most 'chunk_size+12').
@@ -147,7 +147,8 @@ class Wizard:
         :param chunk_size: size of the chunks ot be read.
         """
         self._chunk_size = check_chunk_size(chunk_size, self.encoding)
-        self.reset()
+        if do_reset:
+            self.reset()
         return
 
     def set_encoding(self, encoding: Union[str, pathlib.Path]) -> None:
@@ -170,14 +171,15 @@ class Wizard:
         self.reset()
         return
 
-    def set_time_window(self, time_window: int) -> None:
+    def set_time_window(self, time_window: int, do_reset: bool = True) -> None:
         """
         Sets the time window lenght.
 
         :param buff_size: the time window specified.
         """
         self._time_window = check_time_window(time_window)
-        self.reset()
+        if do_reset:
+            self.reset()
         return
 
     def reset(self) -> None:

--- a/expelliarmus/wizard/wizard.py
+++ b/expelliarmus/wizard/wizard.py
@@ -174,9 +174,9 @@ class Wizard:
 
     def set_time_window(self, time_window: int, do_reset: bool = True) -> None:
         """
-        Sets the time window lenght.
+        Sets the time window length.
 
-        :param buff_size: the time window specified.
+        :param time_window: the time window specified [us].
         :param do_reset: whether or not to reset the wizard after setting the time window.
         """
         self._time_window = check_time_window(time_window)
@@ -304,7 +304,7 @@ class Wizard:
             raise ValueError("ERROR: An input file must be set.")
         self.cargo.events_info.is_chunk = 0
         self.cargo.events_info.is_time_window = 1
-        self.cargo.events_info.time_window = self.time_window * 1000
+        self.cargo.events_info.time_window = self.time_window
         while self.cargo.events_info.finished == 0:
             arr, self.cargo, status = c_read_time_window_wrapper(
                 encoding=self.encoding,

--- a/expelliarmus/wizard/wizard.py
+++ b/expelliarmus/wizard/wizard.py
@@ -145,6 +145,7 @@ class Wizard:
 
         :param fpath: path to the input file.
         :param chunk_size: size of the chunks ot be read.
+        :param do_reset: whether or not to reset the wizard after setting the chunk size.
         """
         self._chunk_size = check_chunk_size(chunk_size, self.encoding)
         if do_reset:
@@ -176,6 +177,7 @@ class Wizard:
         Sets the time window lenght.
 
         :param buff_size: the time window specified.
+        :param do_reset: whether or not to reset the wizard after setting the time window.
         """
         self._time_window = check_time_window(time_window)
         if do_reset:

--- a/tests/test_cut.py
+++ b/tests/test_cut.py
@@ -1,7 +1,7 @@
 import expelliarmus
 from .utils import utils
 
-NEW_DURATION = 15
+NEW_DURATION = 15_000
 
 
 def test_dat_cutting():

--- a/tests/test_time_window.py
+++ b/tests/test_time_window.py
@@ -1,6 +1,6 @@
 from .utils import utils
 
-TIME_WINDOW = 1
+TIME_WINDOW = 1_000
 
 
 def test_dat_time_window():

--- a/tests/utils/utils.py
+++ b/tests/utils/utils.py
@@ -213,7 +213,7 @@ def test_time_window(
         ):  # The last sample duration doesn't count.
             assert (
                 window["t"][-1] - window["t"][0]
-            ) >= time_window * 1000, f"ERROR: The time window length is not the one expected: arr_len -> {len(window)}, duration -> {window['t'][-1]-window['t'][0]}, expected -> {time_window*1000}, finished -> {wizard.cargo.events_info.finished}."
+            ) >= time_window, f"ERROR: The time window length is not the one expected: arr_len -> {len(window)}, duration -> {window['t'][-1]-window['t'][0]}, expected -> {time_window}, finished -> {wizard.cargo.events_info.finished}."
         _test_fields(
             ref_arr[window_offset : window_offset + len(window)], window, sensor_size
         )

--- a/tests/utils/utils.py
+++ b/tests/utils/utils.py
@@ -52,7 +52,7 @@ def test_cut(
     encoding: str,
     fname_in: Union[str, pathlib.Path],
     fname_out: Union[str, pathlib.Path],
-    new_duration: int = 20,
+    new_duration: int = 20_000,
     sensor_size=(640, 480),
 ):
     assert isinstance(fname_in, str) or isinstance(fname_in, pathlib.Path)
@@ -94,7 +94,8 @@ def test_cut(
     ), "The lenght of the array does not coincide with the number of events returned by the C function."
     assert (
         arr["t"][-1] - arr["t"][0]
-    ) >= new_duration * 1000, f"Error: the actual duration of the recording is {(arr['t'][-1] - arr['t'][0])/1000:.2f} ms instead of {new_duration} ms."
+    ) >= new_duration, f"Error: the actual duration of the recording is {(arr['t'][-1] - arr['t'][0])} us instead of {new_duration} us."
+
     # Checking that the cut is consistent.
     _test_fields(ref_arr[:nevents_out], arr, sensor_size)
     nevents_out = wizard.cut(
@@ -106,7 +107,7 @@ def test_cut(
     ), "The lenght of the array does not coincide with the number of events returned by the C function."
     assert (
         arr["t"][-1] - arr["t"][0]
-    ) >= new_duration * 1000, f"Error: the actual duration of the recording is {(arr['t'][-1] - arr['t'][0])/1000:.2f} ms instead of {new_duration} ms."
+    ) >= new_duration, f"Error: the actual duration of the recording is {(arr['t'][-1] - arr['t'][0])} us instead of {new_duration} ms."
     # Checking that the cut is consistent.
     _test_fields(ref_arr[:nevents_out], arr, sensor_size)
     # Cleaning up.


### PR DESCRIPTION
I want to read a file chunked into time windows, and discard the first `T` time steps. This is currently not always possible because when changing the window/chunk size, the wizard is reset. So I would suggest adding a flag `do_reset` to the `change_time_window` and `change_chunk_size` method (which defaults to True, the current behavior).